### PR TITLE
Fix file comment in allocator.cpp

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -24,7 +24,7 @@
  * either License.
  */
 
-/** @file packet_processor.h Packet processor definitions. */
+/** @file allocator.cpp Memory allocation utilities. */
 
 #include "libfreenect2/allocator.h"
 #include "libfreenect2/threading.h"


### PR DESCRIPTION
## Summary
- correct the file-level comment to mention `allocator.cpp`

## Testing
- `cmake ..` *(fails: Package 'libusb-1.0' not found)*
- `make -j$(nproc)` *(fails: No makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb5afd81c83269c4f2713a98d432d