### PR TITLE
Fix filename parsing logic

### DIFF
--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -1523,8 +1523,14 @@ bool parseFrameFilename(const std::string& frame_filename, size_t timestamp_sequ
   size_t ix2 = frame_filename.find("_", ix1 + 1);
   size_t ix3 = frame_filename.find(".", ix2 + 1);
 
+  if(ix1 == std::string::npos || ix2 == std::string::npos || ix3 == std::string::npos)
+  {
+    LOG_ERROR << "wrong filename format";
+    return false;
+  }
+
   std::string ts = frame_filename.substr(0, ix1);
-  std::string seq = frame_filename.substr(ix2 + 1, ix3);
+  std::string seq = frame_filename.substr(ix2 + 1, ix3 - ix2 - 1);
 
   LOG_DEBUG << "ts: " << ts << ", seq: " << seq;
 


### PR DESCRIPTION
## Summary
- correct substring length when parsing filenames
- verify all delimiter positions before using them

## Testing
- `cmake ..` *(fails: Package 'libusb-1.0', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb5ab3a948326b3b4df0cc074cc28