### PR TITLE
Fix logger comments spelling

### DIFF
--- a/examples/Protonect.cpp
+++ b/examples/Protonect.cpp
@@ -70,7 +70,7 @@ void sigusr1_handler(int s)
 /// [pause]
 }
 
-//The following demostrates how to create a custom logger
+//The following demonstrates how to create a custom logger
 /// [logger]
 #include <fstream>
 #include <cstdlib>

--- a/tools/streamer_recorder/ProtonectSR.cpp
+++ b/tools/streamer_recorder/ProtonectSR.cpp
@@ -78,7 +78,7 @@ void sigusr1_handler(int s)
 /// [pause]
 }
 
-//The following demostrates how to create a custom logger
+//The following demonstrates how to create a custom logger
 /// [logger]
 #include <fstream>
 #include <cstdlib>


### PR DESCRIPTION
## Summary
- fix a spelling typo in logger comments in Protonect examples

## Testing
- `grep -n demonstrates -r examples/Protonect.cpp tools/streamer_recorder/ProtonectSR.cpp`

------
https://chatgpt.com/codex/tasks/task_e_683fb5a64b6883269af7fbf153d8c005