### PR TITLE
Fix frame filename parsing indexes

### DIFF
--- a/src/libfreenect2.cpp
+++ b/src/libfreenect2.cpp
@@ -1523,8 +1523,16 @@ bool parseFrameFilename(const std::string& frame_filename, size_t timestamp_sequ
   size_t ix2 = frame_filename.find("_", ix1 + 1);
   size_t ix3 = frame_filename.find(".", ix2 + 1);
 
+  if(ix1 == std::string::npos ||
+     ix2 == std::string::npos ||
+     ix3 == std::string::npos)
+  {
+    LOG_ERROR << "could not find timestamp or sequence markers";
+    return false;
+  }
+
   std::string ts = frame_filename.substr(0, ix1);
-  std::string seq = frame_filename.substr(ix2 + 1, ix3);
+  std::string seq = frame_filename.substr(ix2 + 1, ix3 - ix2 - 1);
 
   LOG_DEBUG << "ts: " << ts << ", seq: " << seq;
 


### PR DESCRIPTION
## Summary
- ensure indices are valid before parsing frame filenames
- correct length when extracting the sequence portion

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fc01980048326a965c34b65c74e70