### PR TITLE
Fix allocator file comment

### DIFF
--- a/src/allocator.cpp
+++ b/src/allocator.cpp
@@ -24,7 +24,7 @@
  * either License.
  */
 
-/** @file packet_processor.h Packet processor definitions. */
+/** @file allocator.cpp Memory allocator implementation. */
 
 #include "libfreenect2/allocator.h"
 #include "libfreenect2/threading.h"


### PR DESCRIPTION
## Summary
- update the header comment in `src/allocator.cpp` to correctly describe the file

## Testing
- `cmake ..` *(fails: Package 'libusb-1.0', required by 'virtual:world', not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc01a69c083268136641485412b18