### PR TITLE
Fix typo in msdirent.h comment

### DIFF
--- a/tools/streamer_recorder/include/msdirent.h
+++ b/tools/streamer_recorder/include/msdirent.h
@@ -284,7 +284,7 @@ static struct dirent *readdir(DIR *dirp)
          return NULL;
       }
       if (FindNextFileA (dirp->search_handle, &dirp->find_data) == FALSE) {
-         /* the very last entry has been processed or an error occured */
+        /* the very last entry has been processed or an error occurred */
          FindClose (dirp->search_handle);
          dirp->search_handle = INVALID_HANDLE_VALUE;
          return NULL;


### PR DESCRIPTION
## Summary
- correct spelling of "occurred" in `tools/streamer_recorder/include/msdirent.h`

## Testing
- `cmake -S . -B build` *(fails: libusb-1.0 not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc01befdc832695afb59c635de1c9